### PR TITLE
Seed the c1 per-SN color coefficient initialization

### DIFF
--- a/saltshaker/training/TrainSALT.py
+++ b/saltshaker/training/TrainSALT.py
@@ -355,7 +355,7 @@ class TrainSALT(TrainSALTBase):
                             guess[parlist==f'x0_{sn}'] = 10**(-0.4*(cosmo.distmod(datadict[sn].zHelio).value-19.36-10.635))
 
                         guess[parlist == 'c0_%s'%sn] = snpar['c'][iSN]
-                        guess[parlist == 'c1_%s'%sn] = np.random.exponential(0.2)
+                        guess[parlist == 'c1_%s'%sn] = rng.exponential(0.2)
                     else:
                         log.warning(f'SN {sn} not found in SN par list {self.options.snparlist}')
                         guess[parlist == 'x0_%s'%sn] = 10**(-0.4*(cosmo.distmod(datadict[sn].zHelio).value-19.36-10.635))


### PR DESCRIPTION
TrainSALT.initializeParameters creates a seeded generator (rng = default_rng(134912348)) for parameter initialization, but the c1_<SN> initialization bypassed it and drew from NumPy's legacy global RNG instead. In a multi-color-law training (len(n_colorpars) > 1), the second per-SN color coefficient therefore got nondeterministic starting values, making runs non-reproducible from the same config and seed.

Use the existing seeded rng, consistent with the x{i}_<SN> initialization a few lines above.